### PR TITLE
Added support for 'mountlate'

### DIFF
--- a/jet/utils.py
+++ b/jet/utils.py
@@ -127,6 +127,7 @@ def load_project(project_file, version):
         "schema": project_yaml.get("schema", False),
         "config-validate": project_yaml.get("config-validate", False),
         "veriexec-ext": project_yaml.get("veriexec-ext", False),
+        "mountlate": project_yaml.get("mountlate", False),
     }
     project_yaml_files = required(project_yaml, "files")
     for file in project_yaml_files:
@@ -203,7 +204,7 @@ def create_package_xml(project, version, package, path):
     etree.SubElement(package_xml, "sb-location").text = "JetEZ"
 
     # XMLPKG_TOGGLE_LIST
-    for p in ("schema", "config-validate", "veriexec-ext"):
+    for p in ("schema", "config-validate", "veriexec-ext", "mountlate"):
         if project[p]:
             etree.SubElement(package_xml, p)
 


### PR DESCRIPTION
YAML file can have 'mountlate: true/false' to enable or disable late mounting third party packages in Junos. This param is first level param and will not come under **files:**.